### PR TITLE
Fix heap overwrite caused by off-by-one error in heap memory allocati…

### DIFF
--- a/Caesar.c
+++ b/Caesar.c
@@ -130,7 +130,7 @@ int main (int argc, char *argv[])
 		
 		char *myMsg = myString();		
 		int myMsgL = strlen(myMsg);
-		char *myMsgE = (char *) malloc(myMsgL*sizeof(char));
+		char *myMsgE = (char *) malloc((myMsgL + 1) *sizeof(char));
 		int i;
 		
 		for (i = 0; i < (myMsgL + 1); i++)


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).…on for the NULL terminator